### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy on Release
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/jakxes/wordle-app/security/code-scanning/1](https://github.com/jakxes/wordle-app/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. In this case, the workflow only needs to read repository contents to check out the code and build the Docker image. Therefore, you should add `permissions: contents: read` at the top level of the workflow file (just below the `name:` and before `on:`), so it applies to all jobs unless overridden. No changes to the steps or other parts of the workflow are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
